### PR TITLE
Productionise bddly npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "bddly",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A nice Behaviour Driven Development testing framework for Jest",
   "main": "lib/index.js",
-  "types": "lib.index.d.ts",
+  "types": "lib/index.d.ts",
   "scripts": {
     "test": "echo \"No test specified\"",
     "build": "tsc",
-    "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
+    "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",

--- a/src/index-template.ts
+++ b/src/index-template.ts
@@ -45,7 +45,7 @@ export const toHTML = (title: string, root: Node) => `
                         </div>
                     </div>
 
-                    <footer class="pt-3 mt-4 text-muted border-top">&copy; 2021</footer>
+                    <footer class="pt-3 mt-4 text-muted border-top">&copy; ${new Date().getFullYear()}</footer>
                 </div>
             </main>
             <script

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const steps: model.Step[] = [];
 const reports: model.Report[] = [];
 const interestingGivens: model.InterestingGiven[] = [];
 const specInfos: model.SpecInfo[] = [];
-const outputDestination = './bdd-reports';
+const outputDestination = './reports/bddly';
 
 let testFailed: boolean;
 let appName: string = 'Bddly reports';
@@ -28,7 +28,7 @@ export const Step = (target: any, methodName: string, descriptor: PropertyDescri
 };
 
 export const interestingGiven = (title: string, data: any) => {
-  interestingGivens.push({ title, data });
+  interestingGivens.push({ title, data: handleParam(data) });
 };
 
 export const report = (title: string, data: string) => {
@@ -98,7 +98,7 @@ const handleParam = (param: any): string => {
     case 'boolean':
       return param ? 'true' : 'false';
     case 'object':
-      return JSON.stringify(param);
+      return JSON.stringify(param, null, 4);
     case 'string':
       return param;
     default:

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import * as model from './model';
 import * as indexTemplate from './index-template';
 import * as fileutils from './file-utils';
@@ -19,8 +20,8 @@ export const save = (): void => {
   fileutils.writeFile('./', workingFile, JSON.stringify(root));
 };
 
-export const getBreadcrumbFromPath = (path: string): string[] => {
-  const pathTokens = path.split('/');
+export const getBreadcrumbFromPath = (filePath: string): string[] => {
+  const pathTokens = filePath.split(path.sep);
   const tailIndex = pathTokens.indexOf(rootName) + 1;
   return pathTokens.splice(tailIndex);
 };

--- a/src/suite-template.ts
+++ b/src/suite-template.ts
@@ -50,7 +50,7 @@ export const toHTML = (title: string, suite: string, reports: model.SpecInfo[], 
 
                     ${reports.map(testTemplate).join('')}
 
-                    <footer class="pt-3 mt-4 text-muted border-top">&copy; 2021</footer>
+                    <footer class="pt-3 mt-4 text-muted border-top">&copy; ${new Date().getFullYear()}</footer>
                 </div>
             </main>
             <script


### PR DESCRIPTION
- Bump patch version to `1.0.2`
- Fix typo in `package.json` > `types` to allow for `import {...} from 'bddly'` syntax
- Replace hardcoded year 2021 in both `index-template.ts` and `suite-template.ts`
- Change output destination to `./reports/bddly`
- Set `JSON.stringify` spacing and apply to interestingGivens for desired formatting
- Fix report generation to be platform agnostic (error with path separator on Windows)