### PR TITLE
Check for presence of `matcherResult` on `JestAssertionError`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export const spec = (name: string, action: () => Promise<void>) => {
       await action();
     } catch (error) {
       testFailed = true;
-      if (error as JestAssertionError) {
+      if (error as JestAssertionError && (error as JestAssertionError).matcherResult) {
         const errorReport = {
           expected: (error as JestAssertionError).matcherResult.expected,
           actual: (error as JestAssertionError).matcherResult.actual,


### PR DESCRIPTION
Some errors don't have a `matcherResult` so cannot be reported on. This change puts a guard around trying to access the missing property, so the error gets thrown.